### PR TITLE
Improve multiplayer support, fixes

### DIFF
--- a/HorseWhistle/ModEntry.cs
+++ b/HorseWhistle/ModEntry.cs
@@ -80,7 +80,7 @@ namespace HorseWhistle
             if (!Context.IsPlayerFree)
                 return;
 
-            if (e.Button == _config.TeleportHorseKey && !Game1.player.isRidingHorse())
+            if (e.Button == _config.TeleportHorseKey && !Game1.player.isRidingHorse() && !Game1.player.isAnimatingMount)
             {
                 var horse = FindHorse();
                 if (horse == null) return;

--- a/HorseWhistle/ModEntry.cs
+++ b/HorseWhistle/ModEntry.cs
@@ -82,6 +82,8 @@ namespace HorseWhistle
 
             if (e.Button == _config.TeleportHorseKey && !Game1.player.isRidingHorse() && !Game1.player.isAnimatingMount)
             {
+                PlayHorseWhistle(); //play the whistle noise for the whistling player (even if the warp doesn't succeed)
+
                 if (Context.IsMainPlayer)
                     WarpHorse();
                 else //if the current player is a multiplayer farmhand
@@ -201,7 +203,6 @@ namespace HorseWhistle
                 return;
 
             //warp the horse to the target player
-            PlayHorseWhistle();
             Game1.warpCharacter(horse, player.currentLocation, player.getTileLocation());
         }
 


### PR DESCRIPTION
This pull request (originally sent to Pathoschild's fork):

* Allows farmhands to whistle for horses at any location available to the host player. When used by farmhands, the whistle command will send a SMAPI multiplayer message to the host's mod, which will warp a horse.
* Prevents warping into the locations that may lose or remove horses. This includes the mineshaft (which removes horses on player exit) and any locations not provided by this mod's GetLocations method (e.g. unusual modded locations).
* Prevents whistling by players currently in the mounting animation.

I hope this helps. Please let me know if there are any issues.